### PR TITLE
add "integer" and "uuid" types from postgres

### DIFF
--- a/Generate POCO.clj
+++ b/Generate POCO.clj
@@ -6,6 +6,8 @@
         [["tinyint"] "byte"]
         [["uniqueidentifier"] "Guid"]
         [["int"] "int"]
+        [["integer"] "int"]
+        [["uuid"] "Guid"]
         [["bigint"] "long"]
         [["char"] "char"]
         [["varbinary" "image"] "byte[]" true] ; cannot be null

--- a/Generate POCO.clj
+++ b/Generate POCO.clj
@@ -4,10 +4,8 @@
     [
         [["bit"] "bool"]
         [["tinyint"] "byte"]
-        [["uniqueidentifier"] "Guid"]
-        [["int"] "int"]
-        [["integer"] "int"]
-        [["uuid"] "Guid"]
+        [["uniqueidentifier" "uuid"] "Guid"]
+        [["int" "integer"] "int"]
         [["bigint"] "long"]
         [["char"] "char"]
         [["varbinary" "image"] "byte[]" true] ; cannot be null


### PR DESCRIPTION
Postgres calls the int type INTEGER, and has a UUID type that is equivalent to a .net System.Guid

Not sure if you initially made this based on MySQL type names in datagrip or where those came from, but with these changes it works perfectly in Postgres (for all the types I use anyway).

--------
Was very thankful to find this project, thanks alot for putting this on Github (I don't know clojure so this woulda been a nightmare to make :) ) 